### PR TITLE
Fix ligand library

### DIFF
--- a/src/MoltimateContainer.js
+++ b/src/MoltimateContainer.js
@@ -53,11 +53,15 @@ function MoltimateContainer(props) {
   function addEClass( className, protein ) {
     if( !searchEClass[className] ) {
         searchEClass[className] = protein;
+        setSearchEClass(searchEClass);
     }
   }
 
   function clearEClass() {
-    setSearchEClass({});
+    Object.keys(searchEClass).forEach( (key) => {
+        delete searchEClass[key];
+    });
+    setSearchEClass(searchEClass);
   }
 
   function handleSelectedResult(e, parentId, childId, active, aligned) {

--- a/src/MoltimateContainer.js
+++ b/src/MoltimateContainer.js
@@ -38,7 +38,7 @@ function MoltimateContainer(props) {
   //the ligand selected to be viewed
   const [viewingLigand, setViewingLigand] = useState(null);
 
-  //protein electron class
+  //protein Enzyme Commission class
   const [searchEClass, setSearchEClass] = useState({});
 
   //the display mode to use for molecules
@@ -50,11 +50,16 @@ function MoltimateContainer(props) {
 
   const [alignmentInProgress, setAlignmentInProgress] = useState(false);
 
-  function addEClass( className, protein ) {
-    if( !searchEClass[className] ) {
-        searchEClass[className] = protein;
-        setSearchEClass(searchEClass);
+  function addEClass( className, protein, search ) {
+    if( search && Object.keys(searchEClass).length != 0 ) {
+        return;
     }
+    if( Object.keys(searchEClass).length != 0 ) {
+        clearEClass();
+    }
+    searchEClass[className] = protein;
+    setSearchEClass(searchEClass);
+    console.log(searchEClass);
   }
 
   function clearEClass() {

--- a/src/common/ResultsBox.js
+++ b/src/common/ResultsBox.js
@@ -7,7 +7,7 @@ import ResultItem from './ResultItem';
 
 
 export default function ResultsBox(props) {
-  const { failedResult, successResult, handleSelectedResult, setEClass, temp } = props;
+  const { failedResult, successResult, handleSelectedResult, temp } = props;
 
   return (
     <div>
@@ -31,7 +31,6 @@ export default function ResultsBox(props) {
         {
           temp ?
             temp.map((m, k) => {
-              if( setEClass ) setEClass(m.ecNumber, m.pdbId);
               return (
                 <ResultItem
                   key={k}

--- a/src/common/ResultsBox.js
+++ b/src/common/ResultsBox.js
@@ -7,8 +7,8 @@ import ResultItem from './ResultItem';
 
 
 export default function ResultsBox(props) {
-  const { failedResult, successResult, handleSelectedResult, temp } = props;
-
+  const { failedResult, successResult, handleSelectedResult, setEClass, temp } = props;
+  if( setEClass && temp && temp.length > 0 ) setEClass(temp[0].ecNumber, temp[0].pdbId, true);
   return (
     <div>
       <List>

--- a/src/search/SearchContainer.js
+++ b/src/search/SearchContainer.js
@@ -49,6 +49,10 @@ function SearchContainer(props) {
     setSelected(pdbId);
     setRes(extra);
 
+    clearEClass();
+    setEClass(pdbId.ecNumber, extra.pdbId);
+    setAlignmentInProgress(true);
+
     handleSelectedResult(e, parentId, childId, active, aligned)
   }
 
@@ -112,7 +116,6 @@ function SearchContainer(props) {
             cardChild={
               <ResultsBox
                 handleSelectedResult={filterHandleSelectedResult}
-                setEClass = {setEClass}
                 temp={ result.data ? result.data.entries : []}
               />
             }

--- a/src/search/SearchContainer.js
+++ b/src/search/SearchContainer.js
@@ -74,7 +74,7 @@ function SearchContainer(props) {
       case 4:
         setExpandBuild(false);
         setExpandResult(true);
-        handleSubmit(e, clearEClass);
+        handleSubmit(e, clearEClass, setEClass);
         break;
       case 5:
         handleClearValues(e)
@@ -116,6 +116,7 @@ function SearchContainer(props) {
             cardChild={
               <ResultsBox
                 handleSelectedResult={filterHandleSelectedResult}
+                setEClass = {setEClass}
                 temp={ result.data ? result.data.entries : []}
               />
             }

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -5,12 +5,12 @@ import testMakerResponse from './testMakerResponse';
 import testSearchResponse from './testSearchResponse';
 
 // TODO make this a config file
-const testQueryURL = 'http://localhost:8080/test/motif';
-const searchQueryURL = 'http://localhost:8080/align/activesite';
-const dockRequestURL = 'http://localhost:8080/dock/dockligand';
-const dockingMoleculeFileRetrievalURL = 'http://localhost:8080/dock/retrievefile';
-const exportDockingInfoURL = 'http://localhost:8080/dock/exportLigands';
-const ligandLibraryURL = 'http://localhost:8080/ligands';
+const testQueryURL = '/test/motif';
+const searchQueryURL = '/align/activesite';
+const dockRequestURL = '/dock/dockligand';
+const dockingMoleculeFileRetrievalURL = '/dock/retrievefile';
+const exportDockingInfoURL = '/dock/exportLigands';
+const ligandLibraryURL = '/ligands';
 
 const useForm = (defaultURL, defaultValues = {}, callback = ()=>{}) => {
   const [values, setValues] = useState(defaultValues);

--- a/src/util/request.js
+++ b/src/util/request.js
@@ -5,12 +5,12 @@ import testMakerResponse from './testMakerResponse';
 import testSearchResponse from './testSearchResponse';
 
 // TODO make this a config file
-const testQueryURL = '/test/motif';
-const searchQueryURL = '/align/activesite';
-const dockRequestURL = '/dock/dockligand';
-const dockingMoleculeFileRetrievalURL = '/dock/retrievefile';
-const exportDockingInfoURL = '/dock/exportLigands';
-const ligandLibraryURL = '/ligands';
+const testQueryURL = 'http://localhost:8080/test/motif';
+const searchQueryURL = 'http://localhost:8080/align/activesite';
+const dockRequestURL = 'http://localhost:8080/dock/dockligand';
+const dockingMoleculeFileRetrievalURL = 'http://localhost:8080/dock/retrievefile';
+const exportDockingInfoURL = 'http://localhost:8080/dock/exportLigands';
+const ligandLibraryURL = 'http://localhost:8080/ligands';
 
 const useForm = (defaultURL, defaultValues = {}, callback = ()=>{}) => {
   const [values, setValues] = useState(defaultValues);


### PR DESCRIPTION
### Description
Changes the ligand library to also load the ligands for the EC class of anything you click on in alignment. As part of this, the array of EC numbers representing what to load is limited to one entry at all times. 

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
