### PR TITLE
Prevent POST-ing empty protein files

### DIFF
--- a/src/util/request.js
+++ b/src/util/request.js
@@ -61,6 +61,11 @@ const useForm = (defaultURL, defaultValues = {}, callback = ()=>{}) => {
       mode: currentMode,
     });
 
+    // POST-ing empty protein files gives an error. Don't do it.
+    if (form_data.get('proteinFiles') == 'undefined') {
+        form_data.delete('proteinFiles')
+    }
+
     axios.post(queryURL, form_data)
       .then(result =>{
         setResult({


### PR DESCRIPTION
MOL-251: POST-ing the search form with the ProteinFiles fields as "undefined" is not a valid request.

### Description
Fix issue MOL-251: File Search bug. If one adds a protein file, then removes it, any POST afterwards will be invalid.

### Checklist
- [x ] Code compiles correctly
- [x ] Created tests which fail without the change (if possible)
- [ x] All tests passing
- [ x] Extended the README / documentation, if necessary
